### PR TITLE
:sparkles: AssetファイルをCloudFrontからCDN配信（S3オリジン）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,9 @@ gem 'mini_magick'
 gem 'aws-sdk-s3', require: false
 # seedデータ生成用
 gem 'faker'
+# AssetsのCDN配信（S3オリジン)
+gem 'asset_sync'
+gem "fog-aws"
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,11 @@ GEM
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    asset_sync (2.7.0)
+      activemodel (>= 4.1.0)
+      fog-core
+      mime-types (>= 2.99)
+      unf
     autoprefixer-rails (9.5.1)
       execjs
     aws-eventstream (1.0.3)
@@ -103,6 +108,7 @@ GEM
     crass (1.0.4)
     diff-lcs (1.3)
     erubi (1.8.0)
+    excon (0.64.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -112,6 +118,23 @@ GEM
     faker (1.9.3)
       i18n (>= 0.7)
     ffi (1.10.0)
+    fog-aws (3.5.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.1.2)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     gon (6.2.1)
@@ -123,6 +146,7 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
+    ipaddress (0.8.3)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -156,6 +180,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0331)
     mimemagic (0.3.3)
     mini_magick (4.9.3)
     mini_mime (1.0.1)
@@ -283,6 +310,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -299,6 +329,7 @@ PLATFORMS
 
 DEPENDENCIES
   acts-as-taggable-on (~> 6.0)
+  asset_sync
   aws-sdk-s3
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
@@ -310,6 +341,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   factory_bot_rails (~> 4.11)
   faker
+  fog-aws
   gon
   gretel
   jbuilder (~> 2.5)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.action_controller.asset_host = '//d32uod5e7asiuu.cloudfront.net'
 
   # Code is not reloaded between requests.
   config.cache_classes = true

--- a/config/initializers/asset_sync.rb
+++ b/config/initializers/asset_sync.rb
@@ -1,0 +1,56 @@
+if defined?(AssetSync)
+  AssetSync.configure do |config|
+    config.fog_provider = 'AWS'
+    config.aws_access_key_id = Rails.application.credentials.dig(:aws, :access_key_id)
+    config.aws_secret_access_key = Rails.application.credentials.dig(:aws, :secret_access_key)
+    # To use AWS reduced redundancy storage.
+    # config.aws_reduced_redundancy = true
+    #
+    # Change AWS signature version. Default is 4
+    # config.aws_signature_version = 4
+    #
+    # Change host option in fog (only if you need to)
+    # config.fog_host = "s3.amazonaws.com"
+    #
+    # Use http instead of https. Default should be "https" (at least for fog-aws)
+    # config.fog_scheme = "http"
+    config.fog_directory = 'kotonoha-assets' 
+
+    # Invalidate a file on a cdn after uploading files
+    # config.cdn_distribution_id = "12345"
+    # config.invalidate = ['file1.js']
+
+    # Increase upload performance by configuring your region
+    config.fog_region = 'ap-northeast-1'
+    #
+    # Set `public` option when uploading file depending on value,
+    # Setting to "default" makes asset sync skip setting the option
+    # Possible values: true, false, "default" (default: true)
+    # config.fog_public = true
+    #
+    # Don't delete files from the store
+    # config.existing_remote_files = "keep"
+    #
+    # Automatically replace files with their equivalent gzip compressed version
+    # config.gzip_compression = true
+    #
+    # Use the Rails generated 'manifest.yml' file to produce the list of files to
+    # upload instead of searching the assets directory.
+    # config.manifest = true
+    #
+    # Upload the manifest file also.
+    # config.include_manifest = false
+    #
+    # Fail silently.  Useful for environments such as Heroku
+    # config.fail_silently = true
+    #
+    # Log silently. Default is `true`. But you can set it to false if more logging message are preferred.
+    # Logging messages are sent to `STDOUT` when `log_silently` is falsy
+    # config.log_silently = true
+    #
+    # Allow custom assets to be cacheable. Note: The base filename will be matched
+    # If you have an asset with name `app.0ba4d3.js`, only `app.0ba4d3` will need to be matched
+    # config.cache_asset_regexps = [ /\.[a-f0-9]{8}$/i, /\.[a-f0-9]{20}$/i ]
+    # config.cache_asset_regexp = /\.[a-f0-9]{8}$/i
+  end
+end


### PR DESCRIPTION
以下の新機能を追加しました。確認お願いします。

assets以下のファイルをCloudFrontからCDN配信
オリジンサーバはS3バケットを指定し、webサーバへの負荷を分散